### PR TITLE
Stage / Phase RC Bump

### DIFF
--- a/src/main/scala/Generator.scala
+++ b/src/main/scala/Generator.scala
@@ -3,7 +3,6 @@ package hwacha
 import scala.collection.mutable.LinkedHashSet
 import freechips.rocketchip.system._
 import freechips.rocketchip.config._
-import freechips.rocketchip.util.GeneratorApp
 
 class VectorAssemblyTestSuite(prefix: String, names: LinkedHashSet[String])(env: String) extends AssemblyTestSuite(prefix, names)(env + "-vec")
 class ScalarVectorAssemblyTestSuite(prefix: String, names: LinkedHashSet[String])(env: String) extends AssemblyTestSuite(prefix, names)(env + "-svec")
@@ -51,103 +50,4 @@ import freechips.rocketchip.system.DefaultTestSuites._
   val hwachaBmarks = new BenchmarkTestSuite("hwacha", "$(RISCV)/riscv64-unknown-elf/share/riscv-tests/benchmarks", LinkedHashSet(
     "pb-spmv", "vec-daxpy", "vec-dgemm-opt", "vec-hsaxpy", "vec-hgemm-opt", "vec-hsgemm-opt", "vec-saxpy", "vec-sdaxpy", "vec-sdgemm-opt", "vec-sgemm-naive", "vec-sgemm-opt", "vec-vvadd"))
 
-}
-
-object Generator extends GeneratorApp {
-  override def addTestSuites {
-  val rv64RegrTestNames = LinkedHashSet(
-        "rv64ud-v-fcvt",
-        "rv64ud-p-fdiv",
-        "rv64ud-v-fadd",
-        "rv64uf-v-fadd",
-        "rv64um-v-mul",
-        "rv64mi-p-breakpoint",
-        "rv64uc-v-rvc",
-        "rv64ud-v-structural",
-        "rv64si-p-wfi",
-        "rv64um-v-divw",
-        "rv64ua-v-lrsc",
-        "rv64ui-v-fence_i",
-        "rv64ud-v-fcvt_w",
-        "rv64uf-v-fmin",
-        "rv64ui-v-sb",
-        "rv64ua-v-amomax_d",
-        "rv64ud-v-move",
-        "rv64ud-v-fclass",
-        "rv64ua-v-amoand_d",
-        "rv64ua-v-amoxor_d",
-        "rv64si-p-sbreak",
-        "rv64ud-v-fmadd",
-        "rv64uf-v-ldst",
-        "rv64um-v-mulh",
-        "rv64si-p-dirty")
-
-  val rv32RegrTestNames = LinkedHashSet(
-      "rv32mi-p-ma_addr",
-      "rv32mi-p-csr",
-      "rv32ui-p-sh",
-      "rv32ui-p-lh",
-      "rv32uc-p-rvc",
-      "rv32mi-p-sbreak",
-      "rv32ui-p-sll")
-
-    import freechips.rocketchip.subsystem.RocketTilesKey
-    import freechips.rocketchip.tile.XLen
-    import DefaultTestSuites._
-    val xlen = params(XLen)
-    // TODO: for now only generate tests for the first core in the first coreplex
-    val tileParams = params(RocketTilesKey).head
-    val coreParams = tileParams.core
-    val vm = coreParams.useVM
-    val env = if (vm) List("p","v") else List("p")
-    coreParams.fpu foreach { case cfg =>
-      if (xlen == 32) {
-        TestGeneration.addSuites(env.map(rv32uf))
-      } else {
-        TestGeneration.addSuite(rv32udBenchmarks)
-        TestGeneration.addSuites(env.map(rv64uf))
-        TestGeneration.addSuites(env.map(rv64ud))
-        if (cfg.divSqrt) {
-          TestGeneration.addSuites(env.map(rv64uf))
-          TestGeneration.addSuites(env.map(rv64ud))
-        }
-      }
-    }
-    if (coreParams.useAtomics) {
-      if (tileParams.dcache.flatMap(_.scratch).isEmpty)
-        TestGeneration.addSuites(env.map(if (xlen == 64) rv64ua else rv32ua))
-      else
-        TestGeneration.addSuites(env.map(if (xlen == 64) rv64uaSansLRSC else rv32uaSansLRSC))
-    }
-    if (coreParams.useCompressed) TestGeneration.addSuites(env.map(if (xlen == 64) rv64uc else rv32uc))
-    val (rvi, rvu) =
-      if (xlen == 64) ((if (vm) rv64i else rv64pi), rv64u)
-      else            ((if (vm) rv32i else rv32pi), rv32u)
-
-    TestGeneration.addSuites(rvi.map(_("p")))
-    TestGeneration.addSuites((if (vm) List("v") else List()).flatMap(env => rvu.map(_(env))))
-    TestGeneration.addSuite(benchmarks)
-    TestGeneration.addSuite(new RegressionTestSuite(if (xlen == 64) rv64RegrTestNames else rv32RegrTestNames))
-
-
-    import HwachaTestSuites._
-    TestGeneration.addSuites(rv64uv.map(_("p")))
-    TestGeneration.addSuites(rv64uv.map(_("vp")))
-    // no excep or vm in v4 yet
-    //TestGeneration.addSuites((if(site(UseVM)) List("pt","v") else List("pt")).flatMap(env => rv64uv.map(_(env))))
-    TestGeneration.addSuite(rv64sv("p"))
-    TestGeneration.addSuite(hwachaBmarks)
-  }
-
-  override def generateTestSuiteMakefrags {
-    addTestSuites
-    var frag = TestGeneration.generateMakefrag + "\nSRC_EXTENSION = $(base_dir)/hwacha/$(src_path)/*.scala" + "\nDISASM_EXTENSION = --extension=hwacha"
-    writeOutputFile(td, s"$longName.d", frag)
-  }
-
-  override lazy val longName = names.topModuleProject + "." + names.configs
-  generateFirrtl
-  generateTestSuiteMakefrags
-  generateArtefacts
-  generateAnno
 }


### PR DESCRIPTION
This removes the generator which uses APIs that have been removed from RC. The chipyard generator subsumes it. 

If for some reason we need to bring this back, we can wait for makefrag features to be upstreamed to RC or we can migrate stage / phase stuff from chipyard to testchipip. 
